### PR TITLE
Add two "wrapper" contracts for easier demo and testing

### DIFF
--- a/contracts/TestCampaign.sol
+++ b/contracts/TestCampaign.sol
@@ -1,0 +1,139 @@
+pragma solidity ^0.5.17;
+
+import "./IAM.sol";
+import "./TestCampaignFactory.sol";
+
+contract TestCampaign {
+    address campaignFactory;
+    address owner;
+    uint256 endDatetime;
+    IAM IAMContract;
+    uint256 totalDonated = 0;
+    uint256 commissionBP = 1000; // 10% == (1000 / 10,000) basis points
+    uint256 basispoints = 10000;
+
+    event campaignInfo(address owner, string status, uint256 endDatetime, uint256 totalDonated);
+    event donationMade(address donor, uint256 donatedAmt);
+    event hasWithdrawn(address from, uint256 totalDonationAmt);
+    event hasRefunded(address donor, uint256 refundedAmt);
+
+    constructor(uint256 secs, address orgAddress, IAM IAMaddress 
+        ) public {
+        endDatetime = block.timestamp + secs;
+        owner = orgAddress;
+        campaignFactory = msg.sender;
+        IAMContract = IAMaddress;
+    }
+
+    // --- MODIFIERS ---
+    modifier ownerOnly() {
+        require(owner == msg.sender, "Caller is not owner");
+        _;
+    }
+
+    modifier verifiedOnly() {
+        require(isVerifiedOwner() == true, "Address is not verified");
+        _;
+    }
+
+    modifier distrustOnly() {
+        require(isDistrustedOwner() == true, "Organisation status is not distrust");
+        _;
+    }
+
+    modifier campaignFactoryOnly() {
+        require(campaignFactory == msg.sender, "Not called from campaignFactory contract");
+        _;
+    }
+
+    modifier ongoingCampaignOnly(bool test_isPastLockout) {
+        require(test_isPastLockout == false, "Campaign has ended");
+        _;
+    }
+
+    modifier pastLockoutOnly(bool test_isPastLockout) {
+        require(test_isPastLockout == true, "Campaign is ongoing");
+        _;
+    }
+
+    // --- GETTERS / SETTERS ---
+    
+    function isVerifiedOwner() public view returns (bool) {
+        return IAMContract.isVerified(owner);
+    }
+
+    function isDistrustedOwner() public view returns (bool) {
+        return IAMContract.isDistrust(owner);
+    }
+
+    function isPastLockout(uint256 test_currentDatetime) public view returns (bool) {
+        return test_currentDatetime >= endDatetime;
+    }
+
+    function getCharityOrganisation() public view returns (address) {
+        return owner;
+    }
+
+    function getCampaignInfo() public {
+        uint256 statusInt = uint256(IAMContract.getStatus(owner));
+        string memory status;
+        if (statusInt == 1) {
+            status = "Verified";
+        } else if (statusInt == 2) {
+            status = "Locked";
+        } else {
+            status = "Distrust";
+        }
+        emit campaignInfo(owner, status, endDatetime, totalDonated);
+    }
+
+    function getEndDatetime() public view returns (uint256) {
+        return endDatetime;
+    }
+
+    function getTotalDonated() public view returns (uint256) {
+        return totalDonated;
+    }
+    
+    // --- FUNCTIONS ---
+    function donate(bool test_isPastLockout) public payable verifiedOnly ongoingCampaignOnly(test_isPastLockout) {
+        require(msg.value > 0, "Invalid donation amount");
+        totalDonated += msg.value;
+        emit donationMade(msg.sender, msg.value);
+    }
+
+    function withdraw(bool test_isPastLockout) public ownerOnly verifiedOnly pastLockoutOnly(test_isPastLockout) {
+        uint256 commission = (totalDonated * commissionBP) / basispoints;
+        
+        address payable campgnFactory = address(uint160(campaignFactory));
+        address payable beneficiary = address(uint160(owner));
+        uint256 netDonationAmt =  totalDonated - commission;
+
+        campgnFactory.transfer(commission);
+        beneficiary.transfer(netDonationAmt);
+        emit hasWithdrawn(beneficiary, netDonationAmt);
+
+        TestCampaignFactory(campaignFactory).closeCampaign(owner, this, test_isPastLockout);
+    }
+
+    // pseudo-code for follow up    
+    function refund(address campaignAddr) public campaignFactoryOnly distrustOnly {
+
+        //retrieve past transactions/events here using campaignAddr
+        /*
+        let contractJSON = require('./CampaignTest.json');
+        let contractABI = contractJSON.abi;
+
+        let CampaignTestContract = new web3.eth.Contract(contractABI, campaignAddr);
+
+        CampaignTestContract.getPastEvents("donationMade", options, (error, events) => {
+        if (error) {
+            console.log(error);
+        } else {
+            //for each event, parse out sender and value
+            //sender.transfer(value)
+            //emit hasRefunded(sender, value);
+        }
+        */
+    }
+}

--- a/contracts/TestCampaignFactory.sol
+++ b/contracts/TestCampaignFactory.sol
@@ -1,0 +1,137 @@
+pragma solidity ^0.5.17;
+
+import "./IAM.sol";
+import "./TestCampaign.sol";
+
+contract TestCampaignFactory {
+    address owner;
+    IAM IAMContract;
+    uint8 MAX_CHARITIES = 5;
+    uint16 HoursInYear = 8760;
+    uint16 SecsInHour = 3600;
+
+    mapping(address => address[]) orgCampaigns;
+
+    event mountCampaign(address organisation, address campaign, uint256 durationHrs);
+    event campaignEnded(address organisation, address campaign);
+    event commissionWithdrawn(uint256 amnt);
+    event campaignDeleted(address organisation, address campaign);
+    event orgDeleted(address organisation);
+    event refundComplete(address organisation);
+    
+    constructor(IAM IAMaddress) public {
+        owner = msg.sender;
+        IAMContract = IAMaddress;
+    }
+
+    // --- MODIFIERS ---
+    modifier ownerOnly() {
+        require(owner == msg.sender, "Caller is not owner");
+        _;
+    }
+
+    modifier verifiedOnly() {
+        require(isVerified(msg.sender) == true, "Address is not verified");
+        _;
+    }
+
+    // --- GETTERS / SETTERS ---
+    
+    function isVerified(address organisation) public view returns (bool) {
+        return IAMContract.isVerified(organisation);
+    }
+    
+    function isLocked(address organisation) public view returns (bool) {
+        return IAMContract.isLocked(organisation);
+    }
+
+    function isDistrust(address organisation) public view returns (bool) {
+        return IAMContract.isDistrust(organisation);
+    }
+
+    function hoursToSeconds(uint16 hrs) private view returns (uint256) {
+        return uint256(SecsInHour  * hrs);
+    }
+
+    function getCampaignsOfOrg(address organisation) public view returns (address[] memory) {
+        return orgCampaigns[organisation];
+    }
+
+    // --- FUNCTIONS ---
+    // overloaded
+    function addCampaign() public verifiedOnly returns (TestCampaign) {
+        require(orgCampaigns[msg.sender].length < MAX_CHARITIES, "Maximum active charities reached");
+        
+        uint256 durationSecs = hoursToSeconds(HoursInYear);
+        TestCampaign c = new TestCampaign(durationSecs, msg.sender, IAMContract);
+        orgCampaigns[msg.sender].push(address(c));
+        
+        emit mountCampaign(msg.sender, address(c), HoursInYear);
+        return c;
+    }
+
+    // overloaded
+    // If organisation specifies duration of campaign in hours
+    function addCampaign(uint16 durationHrs) public verifiedOnly returns (TestCampaign) {
+        require(durationHrs >= 24, "Minimum duration (hrs) is 24 hour");
+        require(durationHrs <= HoursInYear, "Maximum duration (in hrs) is 1 year");
+        require(orgCampaigns[msg.sender].length < MAX_CHARITIES, "Maximum active charities reached");
+        
+        uint256 durationSecs = hoursToSeconds(durationHrs);
+        TestCampaign c = new TestCampaign(durationSecs, msg.sender, IAMContract);
+        orgCampaigns[msg.sender].push(address(c));
+        
+        emit mountCampaign(msg.sender, address(c), durationHrs);
+        return c;
+    }
+
+    // called from Campaign.sol after beneficiary withdraw()
+    function closeCampaign(address organisation, TestCampaign campaign, bool test_isPastLockout) public {
+        require(isVerified(organisation) == true, "Address is not verified");
+        require(test_isPastLockout == true, "Campaign is ongoing");
+        require(tx.origin == organisation, "Caller is not owner");
+        require(msg.sender == address(campaign), "Not called from Campaign contract");
+
+        // delete campaign from active list
+        uint256 len = orgCampaigns[organisation].length - 1;        
+        for (uint i = 0; i < len; i++) {
+            if (orgCampaigns[organisation][i+1] != address(campaign)) {
+                orgCampaigns[organisation][i] = orgCampaigns[organisation][i+1];
+            }
+        }
+        orgCampaigns[organisation].pop();
+        emit campaignEnded(organisation, address(campaign));
+    }
+
+    // withdraw commission
+    function withdrawCommissions() public ownerOnly {
+        require(address(this).balance > 0, "No remaining balance");
+        address payable ownerAddr = address(uint160(owner));
+        uint256 amount = address(this).balance;
+
+        ownerAddr.transfer(amount);
+        emit commissionWithdrawn(amount);
+    }
+    
+    function refundAllCampaigns(address organisation) public ownerOnly {
+        require(isDistrust(organisation) == true, "Organisation status is not distrust");
+        uint256 len = orgCampaigns[organisation].length - 1;
+        for (int i = int(len); i >= 0; i--) {
+            TestCampaign c = TestCampaign(orgCampaigns[organisation][uint256(i)]);
+            c.refund(address(c)); // placeholder
+            deleteCampaignFromMapping(organisation, address(c));
+        }
+        deleteOrgFromMapping(organisation);
+        emit refundComplete(organisation);
+    }
+
+    function deleteCampaignFromMapping(address organisation, address campaignAddr) private {
+        orgCampaigns[organisation].pop();
+        emit campaignDeleted(organisation, campaignAddr);
+    }
+
+    function deleteOrgFromMapping(address organisation) private {
+        delete orgCampaigns[organisation];
+        emit orgDeleted(organisation);
+    }
+}


### PR DESCRIPTION
### CampaignFactory.sol --> TestCampaignFactory.sol
`contract CampaignFactory` -> `contract TestCampaignFactory`

`function closeCampaign(address organisation, TestCampaign campaign, bool test_isPastLockout)`
* Added parameter `bool test_isPastLockout`.
* Function called from TestCampaign.sol, cannot be called directly.

---

### Campaign.sol --> TestCampaign.sol
`contract Campaign` -> `contract TestCampaign`

`function isPastLockout(uint256 test_currentDatetime)`
* Added parameter `uint256 test_currentDatetime`.
* To test, obtain endDatetime from `getEndDatetime()` and add/subtract accordingly before passing to function as arg.

`modifier ongoingCampaignOnly(bool test_isPastLockout)` <br> `modifier pastLockoutOnly(bool test_isPastLockout)` <br> `function donate(bool test_isPastLockout)` <br> `function withdraw(bool test_isPastLockout)`

* Added parameter `bool test_isPastLockout`.
* No longer relies on `isPastLockout()`.
* Allows for easier demo and testing of functions that relies on endDatetime via `bool`.
